### PR TITLE
Install Nuget packages to D: instead of the OS drive

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,6 +20,7 @@ jobs:
     env:
       DOTNET_INSTALL_DIR: D:\dotnet
       GH_TOKEN: ${{ github.token }}
+      NUGET_PACKAGES: ${{ github.workspace }}\.nuget\packages
       bizhawk_hash: ''
       bizhawk_required_files: |
         lib/BizHawk/output/dll/BizHawk.*.dll


### PR DESCRIPTION
Just like .NET itself, this defaults to C:, which may or may not be slow at the moment and for the foreseeable future. Try dropping packages in the workspace instead and see if restores are faster.